### PR TITLE
Interpolation symbols are now considered

### DIFF
--- a/angular-css.js
+++ b/angular-css.js
@@ -35,12 +35,18 @@
       weight: 0
     };
 
-    this.$get = ['$rootScope','$injector','$q','$window','$timeout','$compile','$http','$filter','$log',
-                function $get($rootScope, $injector, $q, $window, $timeout, $compile, $http, $filter, $log) {
+    this.$get = ['$rootScope','$injector','$q','$window','$timeout','$compile','$http','$filter','$log', '$interpolate',
+                function $get($rootScope, $injector, $q, $window, $timeout, $compile, $http, $filter, $log, $interpolate) {
 
       var $css = {};
 
       var template = '<link ng-repeat="stylesheet in stylesheets | orderBy: \'weight\' track by $index " rel="{{ stylesheet.rel }}" type="{{ stylesheet.type }}" ng-href="{{ stylesheet.href }}" ng-attr-media="{{ stylesheet.media }}">';
+
+      // Using correct interpolation symbols.
+      template = template
+        .replace(/{{/g, $interpolate.startSymbol())
+        .replace(/}}/g, $interpolate.endSymbol())
+      ;
 
       // Variables - default options that can be overridden from application config
       var mediaQuery = {}, mediaQueryListener = {}, mediaQueriesToIgnore = ['print'], options = angular.extend({}, defaults),


### PR DESCRIPTION
Angular provides a special [`$interpolateProvider`](https://docs.angularjs.org/api/ng/provider/$interpolateProvider) that you can use to change interpolation symbols from default: `{{`, `}}` to something else, e.g.: `{~`, `~}`. The hardcoded template was breaking this functionality in projects that are using custom interpolation symbols. Now it is fixed.