### PR TITLE
Add NodeJS module that exports Angular module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-css.js');
+module.exports = 'door3.css';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "bugs": {
     "url": "https://github.com/door3/angular-css/issues"
   },
-  "main": "angular-css.js",
+  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This makes it easier to import this module for use in webpack and browserify:

```javascript
angular.module('myModule', [
    require('angular-css')
]);
```